### PR TITLE
新規登録機能を手動バリデーションに変更するためのインターフェース追加

### DIFF
--- a/src/main/java/com/example/demo/validation/ValidationOrder.java
+++ b/src/main/java/com/example/demo/validation/ValidationOrder.java
@@ -1,0 +1,14 @@
+package com.example.demo.validation;
+
+import jakarta.validation.GroupSequence;
+
+import com.example.demo.validation.group.EmailGroup;
+import com.example.demo.validation.group.NotBlankGroup;
+import com.example.demo.validation.group.PatternGroup;
+import com.example.demo.validation.group.SizeGroup;
+
+// バリデーション制御用のアノテーション。()内の順序でエラーが出た時点のみエラーを1つ出力。
+@GroupSequence({NotBlankGroup.class,EmailGroup.class,PatternGroup.class,SizeGroup.class})
+public interface ValidationOrder {
+
+}

--- a/src/main/java/com/example/demo/validation/group/EmailGroup.java
+++ b/src/main/java/com/example/demo/validation/group/EmailGroup.java
@@ -1,0 +1,5 @@
+package com.example.demo.validation.group;
+
+public interface EmailGroup {
+
+}

--- a/src/main/java/com/example/demo/validation/group/NotBlankGroup.java
+++ b/src/main/java/com/example/demo/validation/group/NotBlankGroup.java
@@ -1,0 +1,5 @@
+package com.example.demo.validation.group;
+
+public interface NotBlankGroup {
+
+}

--- a/src/main/java/com/example/demo/validation/group/PatternGroup.java
+++ b/src/main/java/com/example/demo/validation/group/PatternGroup.java
@@ -1,0 +1,5 @@
+package com.example.demo.validation.group;
+
+public interface PatternGroup {
+
+}

--- a/src/main/java/com/example/demo/validation/group/SizeGroup.java
+++ b/src/main/java/com/example/demo/validation/group/SizeGroup.java
@@ -1,0 +1,5 @@
+package com.example.demo.validation.group;
+
+public interface SizeGroup {
+
+}


### PR DESCRIPTION
自動バリデーションでは表示順を制御できないため、手動バリデーションに変更。
指定したGroup順に評価され、エラーが発生した時点で評価が終了し、エラー1件のみを返す。